### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/basket-api.yml
+++ b/.github/workflows/basket-api.yml
@@ -109,7 +109,7 @@ jobs:
       run: |
         cp ${{ env.ARTIFACT_NAME }}/basket.api ./src/backend/services/basket.api/
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ env.IMAGE_NAME }}
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/identity-api.yml
+++ b/.github/workflows/identity-api.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         cp -r identity_api/ ./src/backend/services/identity.api/identity-api-release
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jurabek/menu
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/menu-api.yml
+++ b/.github/workflows/menu-api.yml
@@ -80,7 +80,7 @@ jobs:
         ls -a
         cp -r menu_api/ ./src/backend/services/menu.api/menu-api-release
     - name: Publish docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jurabek/menu
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/order-api.yml
+++ b/.github/workflows/order-api.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           cp order_api/order.api.jar ./src/backend/services/order.api/
       - name: Publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: jurabek/order
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore